### PR TITLE
Correção de bug em mensagem de erro do Kiwi

### DIFF
--- a/kiwi/ui/widgets/entry.py
+++ b/kiwi/ui/widgets/entry.py
@@ -167,7 +167,7 @@ class ProxyEntry(KiwiEntry, ValidatableProxyWidgetMixin):
 
         if self.get_text() and value is None:
             raise ValidationError(
-                _("'%s' is not a valid object" % (self.get_text(), )))
+                _("'%s' is not a valid object") % self.get_text())
 
     def read(self):
         mode = self._mode


### PR DESCRIPTION
Ao utilizar o widget entry do Kiwi, quando acontecia um erro de validação, a mensagem de erro que aparecia no campo vinha sempre em inglês (a tradução não acontecia). A culpa estava nesta linha, que fazia o replace do %s antes de mandar para a função de tradução.