### PR TITLE
Removing the master/slave lingo

### DIFF
--- a/examples/framework/news/news.py
+++ b/examples/framework/news/news.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from gi.repository import Gtk
 
-from kiwi.ui.views import BaseView, SlaveView
+from kiwi.ui.views import BaseView, SubordinateView
 from kiwi.ui.gadgets import quit_if_last
 
 news = [
@@ -23,7 +23,7 @@ news = [
 ]
 
 
-class News(SlaveView):
+class News(SubordinateView):
     def __init__(self):
         model = Gtk.ListStore(str, str)
         treeview = Gtk.TreeView(model)
@@ -35,13 +35,13 @@ class News(SlaveView):
         treeview.get_selection().set_mode(Gtk.SelectionMode.BROWSE)
         for item in news:
             model.append(item[:-1])
-        SlaveView.__init__(self, treeview)
+        SubordinateView.__init__(self, treeview)
 
 news = News()
 
 shell = BaseView(gladefile="news_shell.ui",
                  delete_handler=quit_if_last)
-shell.attach_slave("placeholder", news)
+shell.attach_subordinate("placeholder", news)
 
 news.show_all()
 news.focus_toplevel()  # explained next section, don't worry

--- a/examples/framework/news/news3.py
+++ b/examples/framework/news/news3.py
@@ -5,7 +5,7 @@ import os
 from gi.repository import Gtk
 
 from kiwi.ui import gadgets
-from kiwi.ui.delegates import Delegate, SlaveDelegate
+from kiwi.ui.delegates import Delegate, SubordinateDelegate
 from kiwi.ui.objectlist import ObjectList, Column
 
 
@@ -51,15 +51,15 @@ class Shell(Delegate):
         objectlist = ObjectList(my_columns, news)
         objectlist.connect('selection-changed', self.news_selected)
         objectlist.connect('double-click', self.double_click)
-        slave = SlaveDelegate(toplevel=objectlist)
+        subordinate = SubordinateDelegate(toplevel=objectlist)
 
-        self.attach_slave("placeholder", slave)
-        slave.focus_toplevel()  # Must be done after attach
+        self.attach_subordinate("placeholder", subordinate)
+        subordinate.focus_toplevel()  # Must be done after attach
 
-        self.slave = slave
+        self.subordinate = subordinate
 
     def news_selected(self, the_list, item):
-        self.slave.get_toplevel()
+        self.subordinate.get_toplevel()
         print("%s %s %s\n" % (item.title, item.author, item.url))
 
     def double_click(self, the_list, selected_object):
@@ -67,7 +67,7 @@ class Shell(Delegate):
         self.hide_and_quit()
 
     def on_ok__clicked(self, *args):
-        objectlist = self.slave.get_toplevel()
+        objectlist = self.subordinate.get_toplevel()
         item = objectlist.get_selected()
         if item:
             self.emit('result', item.url)

--- a/examples/framework/news/news4.py
+++ b/examples/framework/news/news4.py
@@ -5,7 +5,7 @@ import os
 
 from gi.repository import Gtk, Gdk
 
-from kiwi.ui.delegates import GladeDelegate, SlaveDelegate
+from kiwi.ui.delegates import GladeDelegate, SubordinateDelegate
 from kiwi.ui.gadgets import quit_if_last, set_background, set_foreground
 from kiwi.ui.objectlist import Column, ObjectList
 
@@ -30,14 +30,14 @@ news = [
 ]
 
 
-class ListSlave(SlaveDelegate):
+class ListSubordinate(SubordinateDelegate):
     def __init__(self, parent):
         self.parent = parent
         self.news_list = ObjectList([
             Column('title', 'Title of article', str),
             Column('author', 'Author of article', str),
             Column('url', 'Address of article', str)])
-        SlaveDelegate.__init__(self, toplevel=self.news_list)
+        SubordinateDelegate.__init__(self, toplevel=self.news_list)
         self.news_list.add_list(news)
         self.news_list.select(self.news_list[0])
 
@@ -64,13 +64,13 @@ class Shell(GladeDelegate):
         set_background(self.footer, "#A0A0A0")
         set_foreground(self.title, "blue")
 
-        self.slave = ListSlave(self)
-        self.attach_slave("placeholder", self.slave)
-        self.slave.show()
-        self.slave.focus_toplevel()  # Must be done after attach
+        self.subordinate = ListSubordinate(self)
+        self.attach_subordinate("placeholder", self.subordinate)
+        self.subordinate.show()
+        self.subordinate.focus_toplevel()  # Must be done after attach
 
     def on_ok__clicked(self, button):
-        item = self.slave.news_list.get_selected()
+        item = self.subordinate.news_list.get_selected()
         self.emit('result', item.url)
         self.hide_and_quit()
 

--- a/examples/framework/sizegroup/slaves.py
+++ b/examples/framework/sizegroup/slaves.py
@@ -1,32 +1,32 @@
 #!/usr/bin/env python
 from gi.repository import Gtk
 
-from kiwi.ui.delegates import GladeDelegate, GladeSlaveDelegate
+from kiwi.ui.delegates import GladeDelegate, GladeSubordinateDelegate
 from kiwi.ui.gadgets import quit_if_last
 
 
-class NestedSlave(GladeSlaveDelegate):
+class NestedSubordinate(GladeSubordinateDelegate):
     def __init__(self, parent):
         self.parent = parent
-        GladeSlaveDelegate.__init__(self, gladefile="slave_view2.ui",
+        GladeSubordinateDelegate.__init__(self, gladefile="subordinate_view2.ui",
                                     toplevel_name="window_container")
 
 
-# This slave will be attached to the toplevel view, and will contain another
-# slave
-class TestSlave(GladeSlaveDelegate):
+# This subordinate will be attached to the toplevel view, and will contain another
+# subordinate
+class TestSubordinate(GladeSubordinateDelegate):
     def __init__(self, parent):
         self.parent = parent
         # Be carefull that, when passing the widget list, the sizegroups
         # that you want to be merged are in the list, otherwise, they wont
         # be.
-        GladeSlaveDelegate.__init__(self, gladefile="slave_view.ui",
+        GladeSubordinateDelegate.__init__(self, gladefile="subordinate_view.ui",
                                     toplevel_name="window_container")
 
-        self.slave = NestedSlave(self)
-        self.attach_slave("eventbox", self.slave)
-        self.slave.show()
-        self.slave.focus_toplevel()  # Must be done after attach
+        self.subordinate = NestedSubordinate(self)
+        self.attach_subordinate("eventbox", self.subordinate)
+        self.subordinate.show()
+        self.subordinate.focus_toplevel()  # Must be done after attach
 
 
 class Shell(GladeDelegate):
@@ -34,10 +34,10 @@ class Shell(GladeDelegate):
         GladeDelegate.__init__(self, gladefile="shell.ui",
                                delete_handler=quit_if_last)
 
-        self.slave = TestSlave(self)
-        self.attach_slave("placeholder", self.slave)
-        self.slave.show()
-        self.slave.focus_toplevel()  # Must be done after attach
+        self.subordinate = TestSubordinate(self)
+        self.attach_subordinate("placeholder", self.subordinate)
+        self.subordinate.show()
+        self.subordinate.focus_toplevel()  # Must be done after attach
 
     def on_ok__clicked(self, *args):
         self.hide_and_quit()

--- a/examples/validation/slaves.py
+++ b/examples/validation/slaves.py
@@ -3,7 +3,7 @@ from gi.repository import Gtk, Gio
 
 from kiwi.datatypes import ValidationError
 from kiwi.ui.widgets.combo import ProxyComboEntry
-from kiwi.ui.delegates import GladeDelegate, SlaveDelegate
+from kiwi.ui.delegates import GladeDelegate, SubordinateDelegate
 
 
 class Dialog(GladeDelegate):
@@ -30,7 +30,7 @@ class Dialog(GladeDelegate):
         raise SystemExit
 
 
-class English(SlaveDelegate):
+class English(SubordinateDelegate):
     def __init__(self):
         box = Gtk.HBox(spacing=6)
         box.set_border_width(6)
@@ -48,14 +48,14 @@ class English(SlaveDelegate):
         box.pack_start(combo, True, True, 0)
         self.combo = combo
 
-        SlaveDelegate.__init__(self, toplevel=box, widgets=['combo'])
+        SubordinateDelegate.__init__(self, toplevel=box, widgets=['combo'])
 
     def on_combo__validate(self, widget, data):
         if data != 'Two':
             return ValidationError("foo")
 
 
-class Swedish(SlaveDelegate):
+class Swedish(SubordinateDelegate):
     def __init__(self):
         box = Gtk.HBox(spacing=6)
         box.set_border_width(6)
@@ -73,7 +73,7 @@ class Swedish(SlaveDelegate):
         box.pack_start(combo, True, True, 0)
         self.combo = combo
 
-        SlaveDelegate.__init__(self, toplevel=box, widgets=['combo'])
+        SubordinateDelegate.__init__(self, toplevel=box, widgets=['combo'])
 
     def on_combo__validate(self, widget, data):
         if data != 'Tre':
@@ -96,7 +96,7 @@ babe.number = 'One'
 
 eng = English()
 eng.show()
-dialog.attach_slave("english", eng)
+dialog.attach_subordinate("english", eng)
 eng.add_proxy(babe, ['combo'])
 
 # Swedish part
@@ -105,7 +105,7 @@ brud.nummer = 'Ett'
 
 swe = Swedish()
 swe.show()
-dialog.attach_slave("swedish", swe)
+dialog.attach_subordinate("swedish", swe)
 swe.add_proxy(brud, ['combo'])
 dialog.show_all()
 

--- a/kiwi/interfaces.py
+++ b/kiwi/interfaces.py
@@ -166,11 +166,11 @@ class AbstractGladeAdaptor(Interface):
     def get_widgets(self):
         """Return a tuple with all the widgets in the glade file"""
 
-    def attach_slave(self, name, slave):
-        """Attaches a slaveview to the view this adaptor belongs to,
+    def attach_subordinate(self, name, subordinate):
+        """Attaches a subordinateview to the view this adaptor belongs to,
         substituting the widget specified by name.
         The widget specified *must* be a eventbox; its child widget will be
-        removed and substituted for the specified slaveview's toplevel widget
+        removed and substituted for the specified subordinateview's toplevel widget
         """
 
     def signal_autoconnect(self, dic):

--- a/kiwi/ui/delegates.py
+++ b/kiwi/ui/delegates.py
@@ -25,7 +25,7 @@
 
 """Defines the Delegate classes that are included in the Kiwi Framework."""
 
-from kiwi.ui.views import SlaveView, BaseView
+from kiwi.ui.views import SubordinateView, BaseView
 from kiwi.controllers import BaseController
 
 
@@ -66,26 +66,26 @@ class GladeDelegate(BaseView, BaseController):
         BaseController.__init__(self, view=self, keyactions=keyactions)
 
 
-class SlaveDelegate(SlaveView, BaseController):
+class SubordinateDelegate(SubordinateView, BaseController):
     """A class that combines view and controller functionality into a
     single package. It does not possess a top-level window, but is instead
-    intended to be plugged in to a View or Delegate using attach_slave().
+    intended to be plugged in to a View or Delegate using attach_subordinate().
     """
     def __init__(self, toplevel=None, widgets=None,
                  toplevel_name=None, keyactions=None):
         """
         The keyactions parameter is sent to :class:`kiwi.controllers.BaseController`,
-        the rest are sent to :class:`kiwi.ui.views.SlaveView`
+        the rest are sent to :class:`kiwi.ui.views.SubordinateView`
         """
         widgets = widgets or []
-        SlaveView.__init__(self, toplevel, widgets, toplevel_name)
+        SubordinateView.__init__(self, toplevel, widgets, toplevel_name)
         BaseController.__init__(self, view=self, keyactions=keyactions)
 
 
-class GladeSlaveDelegate(SlaveView, BaseController):
+class GladeSubordinateDelegate(SubordinateView, BaseController):
     """A class that combines view and controller functionality into a
     single package. It does not possess a top-level window, but is instead
-    intended to be plugged in to a View or Delegate using attach_slave().
+    intended to be plugged in to a View or Delegate using attach_subordinate().
     """
     def __init__(self, gladefile=None,
                  toplevel_name=None, domain=None,
@@ -94,7 +94,7 @@ class GladeSlaveDelegate(SlaveView, BaseController):
         The keyactions parameter is sent to :class:`kiwi.controllers.BaseController`,
         the rest are sent to :class:`kiwi.ui.views.SlavseView`
         """
-        SlaveView.__init__(self,
+        SubordinateView.__init__(self,
                            gladefile=gladefile,
                            toplevel_name=toplevel_name,
                            domain=domain)
@@ -145,10 +145,10 @@ class ProxyDelegate(Delegate):
         self.proxy.update(attribute)
 
 
-class ProxySlaveDelegate(GladeSlaveDelegate):
+class ProxySubordinateDelegate(GladeSubordinateDelegate):
     """A class that combines view, controller and proxy functionality into a
     single package. It does not possess a top-level window, but is instead
-    intended to be plugged in to a View or Delegate using attach_slave()
+    intended to be plugged in to a View or Delegate using attach_subordinate()
 
     :ivar model: the model
     :ivar proxy: the proxy
@@ -162,7 +162,7 @@ class ProxySlaveDelegate(GladeSlaveDelegate):
         the rest are sent to :class:`kiwi.ui.views.BaseView`
         """
 
-        GladeSlaveDelegate.__init__(self, gladefile, toplevel_name,
+        GladeSubordinateDelegate.__init__(self, gladefile, toplevel_name,
                                     domain, keyactions)
         self.model = model
         self.proxy = self.add_proxy(model, proxy_widgets)

--- a/kiwi/ui/proxy.py
+++ b/kiwi/ui/proxy.py
@@ -77,7 +77,7 @@ class Proxy:
     def __init__(self, view, model=None, widgets=()):
         """
         Create a new Proxy object.
-        :param view:    view attched to the slave
+        :param view:    view attched to the subordinate
         :type  view:    a :class:`kiwi.ui.views.BaseView` subclass
         :param model:   model attached to proxy
         :param widgets: the widget names


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.